### PR TITLE
add AllowCredentials() for cors-builder

### DIFF
--- a/src/middlewares/cors-builder.test.ts
+++ b/src/middlewares/cors-builder.test.ts
@@ -5,12 +5,18 @@ const { test } = Deno;
 
 test(function testCorsBuilder() {
   const builder = new CorsBuilder();
-  const response: Response = { headers: new Headers()};
+  const response: Response = { headers: new Headers() };
 
-  builder.WithOrigins('http://localhost:8000').AllowAnyMethod();
+  builder
+    .WithOrigins('http://localhost:8000')
+    .WithMethods('PUT, OPTIONS')
+    .WithHeaders('X-Custom-Header, Upgrade-Insecure-Requests')
+    .AllowCredentials();
 
-  builder.onPostRequest({} as ServerRequest, response).then(()  => {
+  builder.onPostRequest({} as ServerRequest, response).then(() => {
     assert(response && response.headers && response.headers.get('Access-Control-Allow-Origin') === 'http://localhost:8000');
-    assert(response && response.headers && response.headers.get('Access-Control-Allow-Methods') === '*');
+    assert(response && response.headers && response.headers.get('Access-Control-Allow-Methods') === 'PUT, OPTIONS');
+    assert(response && response.headers && response.headers.get('Access-Control-Allow-Headers') === 'X-Custom-Header, Upgrade-Insecure-Requests');
+    assert(response && response.headers && response.headers.get('Access-Control-Allow-Credentials') === 'true');
   });
 });

--- a/src/middlewares/cors-builder.ts
+++ b/src/middlewares/cors-builder.ts
@@ -3,43 +3,78 @@ import { Response, ServerRequest } from '../mod.ts';
 
 
 export class CorsBuilder implements MiddlwareTarget {
-    private headers: Map<string, string>;
-  
-    constructor() {
-      this.headers = new Map();
-    }
+  private headers: Map<string, string>;
+  private allowAnyOrigin: boolean;
+  private allowAnyMethod: boolean;
+  private allowAnyHeader: boolean;
 
-    onPreRequest(request: ServerRequest, responce: Response) {
-      return new Promise((res, rej) => {
-        res();
-      });
-    }
-
-    onPostRequest(request: ServerRequest, responce: Response) {
-      return new Promise((resolve, rej) => {
-        this.headers.forEach((el, key) => {
-          
-          if(responce.headers){
-            responce.headers.set(key, el);
-          };
-
-        });
-        resolve();
-      });
-    }
-
-    WithOrigins(origins: string) {
-      this.headers.set('Access-Control-Allow-Origin', origins);
-      return this;
-    }
-
-    AllowAnyMethod() {
-      this.headers.set('Access-Control-Allow-Methods', '*');
-      return this;
-    }
-
-    AllowAnyHeaders() {
-      this.headers.set('Access-Control-Allow-Headers', '*');
-      return this;
-    }
+  constructor() {
+    this.headers = new Map();
+    this.allowAnyOrigin = false;
+    this.allowAnyMethod = false;
+    this.allowAnyHeader = false;
   }
+
+  onPreRequest(request: ServerRequest, responce: Response) {
+    return new Promise((res, rej) => {
+      if (this.allowAnyOrigin) {
+        this.headers.set('Access-Control-Allow-Origin', request.headers.get('Origin') || '');
+      }
+      if (this.allowAnyMethod) {
+        this.headers.set('Access-Control-Allow-Methods', request.headers.get('Access-Control-Request-Method') || '');
+      }
+      if (this.allowAnyHeader) {
+        this.headers.set('Access-Control-Allow-Headers', request.headers.get('Access-Control-Request-Headers') || '');
+      }
+      res();
+    });
+  }
+
+  onPostRequest(request: ServerRequest, responce: Response) {
+    return new Promise((resolve, rej) => {
+      this.headers.forEach((el, key) => {
+
+        if (responce.headers) {
+          responce.headers.set(key, el);
+        };
+
+      });
+      resolve();
+    });
+  }
+
+  WithOrigins(origins: string) {
+    this.headers.set('Access-Control-Allow-Origin', origins);
+    return this;
+  }
+
+  WithMethods(methods: string) {
+    this.headers.set('Access-Control-Allow-Methods', methods);
+    return this;
+  }
+
+  WithHeaders(headers: string) {
+    this.headers.set('Access-Control-Allow-Headers', headers);
+    return this;
+  }
+
+  AllowAnyOrigin() {
+    this.allowAnyOrigin = true;
+    return this;
+  }
+
+  AllowAnyMethod() {
+    this.allowAnyMethod = true;
+    return this;
+  }
+
+  AllowAnyHeader() {
+    this.allowAnyHeader = true;
+    return this;
+  }
+
+  AllowCredentials() {
+    this.headers.set('Access-Control-Allow-Credentials', 'true')
+    return this;
+  }
+}


### PR DESCRIPTION
- added AllowCredentials() method 
- make allow any methods to set headers based on the request headers as sometimes the browsers do not support wildcard(*)