### PR TITLE
fix getting multiple static files

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -125,7 +125,7 @@ export class App {
       // try getting static file
       if (await this.getStaticFile(req, res)) {
         await req.respond(res);
-        return;
+        continue;
       }
 
       // try respond for OPTIONS request, TODO: allowed method


### PR DESCRIPTION
when a static file is loaded, the function exists,
meaning that nothing else can be loaded

instead continue to the next request instead of exiting