### PR TITLE
update to deno 0.41.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 variables:
-    DENO_VERSION: 'v0.40.0'
+    DENO_VERSION: 'v0.41.0'
 
 install:
     - curl -fsSL https://deno.land/x/install/install.sh | sh -s $(DENO_VERSION)

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM maxmcd/deno:jessie-v0.40.0
+FROM maxmcd/deno:jessie-v0.41.0
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/src/package.ts
+++ b/src/package.ts
@@ -1,4 +1,4 @@
-export { serve, Server, ServerRequest, Response } from 'https://deno.land/std@v0.40.0/http/server.ts';
+export { serve, Server, ServerRequest, Response } from 'https://deno.land/std@v0.41.0/http/server.ts';
 export {
     normalize,
     basename,
@@ -8,9 +8,9 @@ export {
     join,
     resolve,
     isAbsolute,
-} from 'https://deno.land/std@v0.40.0/path/mod.ts';
+} from 'https://deno.land/std@v0.41.0/path/mod.ts';
 
-export { getCookies } from 'https://deno.land/std@v0.40.0/http/cookie.ts';
+export { getCookies } from 'https://deno.land/std@v0.41.0/http/cookie.ts';
 export { contentType } from 'https://deno.land/x/media_types/mod.ts';
 
 export { renderFile } from 'https://deno.land/x/dejs@0.3.3/mod.ts';

--- a/src/package_test.ts
+++ b/src/package_test.ts
@@ -4,4 +4,4 @@ export {
     assertStrictEq,
     assertThrows,
     assertThrowsAsync,
-} from 'https://deno.land/std@v0.40.0/testing/asserts.ts';
+} from 'https://deno.land/std@v0.41.0/testing/asserts.ts';

--- a/src/static/send.ts
+++ b/src/static/send.ts
@@ -75,7 +75,7 @@ function isHidden(root: string, path: string) {
 
 async function exists(path: string): Promise<boolean> {
   try {
-    return (await Deno.stat(path)).isFile();
+    return (await Deno.stat(path)).isFile;
   } catch {
     return false;
   }
@@ -148,7 +148,7 @@ export async function send(
   try {
       stats = await Deno.stat(path);
 
-    if (stats.isDirectory()) {
+    if (stats.isDirectory) {
       if (format && index) {
         path += `/${index}`;
         stats = await Deno.stat(path);


### PR DESCRIPTION
due to deno version 0.41.0, the FileInfo interface has changed: denoland/deno/pull/4763, which breaks the build.

this patches fixes the build and updates the project to deno 0.41.0.

suggestion: use import maps (https://deno.land/std/manual.md#import-maps) in order to make future updates easier.