### PR TITLE
Examples: update Eta version, use new Eta partial syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Alosaur - [Deno](https://github.com/denoland) web framework 🦖.
 - [SPA middleware](https://github.com/alosaur/alosaur/tree/master/examples/spa)
 - [Static content middleware](https://github.com/alosaur/alosaur/tree/master/examples/static)
 - [Database PostgreSQL](https://github.com/alosaur/alosaur/tree/master/examples/db)
-- Template render: [Dejs](https://github.com/alosaur/alosaur/tree/master/examples/dejs), [Handlebars](https://github.com/alosaur/alosaur/tree/master/examples/handlebars), [Angular](https://github.com/alosaur/alosaur/tree/master/examples//angular)
+- Template render: [Dejs](https://github.com/alosaur/alosaur/tree/master/examples/dejs), [Handlebars](https://github.com/alosaur/alosaur/tree/master/examples/handlebars), [Angular](https://github.com/alosaur/alosaur/tree/master/examples//angular), [Eta](https://github.com/alosaur/alosaur/tree/master/examples/eta)
 - [Body transform, validator](https://github.com/alosaur/alosaur/tree/master/examples/validator)
 - [DI](https://github.com/alosaur/alosaur/tree/master/examples/di)
 - [Docker](https://github.com/alosaur/alosaur/tree/master/examples/docker)
@@ -269,7 +269,7 @@ return View("page", 404); // return 404 status
 ## Render pages
 
 Alosaur can suppport any html renderer. All you have to do is define the rendering function in the settings.
-For example [Dejs](https://github.com/alosaur/alosaur/tree/master/examples/dejs), [Handlebars](https://github.com/alosaur/alosaur/tree/master/examples/handlebars), [Angular](https://github.com/alosaur/angular_deno)
+For example [Dejs](https://github.com/alosaur/alosaur/tree/master/examples/dejs), [Handlebars](https://github.com/alosaur/alosaur/tree/master/examples/handlebars), [Angular](https://github.com/alosaur/angular_deno), [Eta](https://github.com/alosaur/alosaur/tree/master/examples/eta)
 
 
 ```ts

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 - [SPA middleware](https://github.com/alosaur/alosaur/tree/master/examples/spa)
 - [Static content middleware](https://github.com/alosaur/alosaur/tree/master/examples/static)
 - [Database PostgreSQL](https://github.com/alosaur/alosaur/tree/master/examples/db)
-- Template render: [Dejs](https://github.com/alosaur/alosaur/tree/master/examples/dejs) and [Handlebars](https://github.com/alosaur/alosaur/tree/master/examples/handlebars)
+- Template render: [Dejs](https://github.com/alosaur/alosaur/tree/master/examples/dejs), [Handlebars](https://github.com/alosaur/alosaur/tree/master/examples/handlebars), and [Eta](https://github.com/alosaur/alosaur/tree/master/examples/eta)
 - [Body transform, validator](https://github.com/alosaur/alosaur/tree/master/examples/validator)
 - [DI](https://github.com/alosaur/alosaur/tree/master/examples/di)
 - [Docker](https://github.com/alosaur/alosaur/tree/master/examples/docker)

--- a/examples/eta/app.ts
+++ b/examples/eta/app.ts
@@ -1,4 +1,4 @@
-import { renderFile, configure } from "https://deno.land/x/eta@v1.5.0/mod.ts";
+import { renderFile, configure } from "https://deno.land/x/eta@v1.6.0/mod.ts";
 import { App, Area, Controller, Get, QueryParam, View } from "../../mod.ts";
 
 const viewPath = `${Deno.cwd()}/examples/eta/views/`;

--- a/examples/eta/views/main.eta
+++ b/examples/eta/views/main.eta
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
-  <%~ await E.includeFile('./header', { title: 'Eta' }) %>
+  <%~ await includeFile('./header', { title: 'Eta' }) %>
   <body>
     <h1>Hello, world!</h1>
     <p>Hi <%~ it.name %></p>
-    <%~ await E.includeFile('./footer') %>
+    <%~ await includeFile('./footer') %>
   </body>
 </html>


### PR DESCRIPTION
As of version 1.6.0, Eta supports `<%~ include(filepath) %>` as well as `<%~ E.include(filepath) %>`. Since the new syntax is more readable, I thought updating the examples would make them more understandable and user-friendly.