### PR TITLE
Change all type re-exports to use `export type` syntax

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -18,11 +18,11 @@ export * from "./src/models/mod.ts";
 
 // Deps
 export {
-  HTTPOptions,
   serve,
   Server,
   ServerRequest,
 } from "https://deno.land/std@0.74.0/http/server.ts";
+export type { HTTPOptions } from "https://deno.land/std@0.74.0/http/server.ts";
 
 // Version
 export * from "./src/version.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,9 +1,11 @@
 export {
-  HTTPOptions,
-  Response,
   serve,
   Server,
   ServerRequest,
+} from "https://deno.land/std@0.74.0/http/server.ts";
+export type {
+  HTTPOptions,
+  Response,
 } from "https://deno.land/std@0.74.0/http/server.ts";
 export { getCookies } from "https://deno.land/std@0.74.0/http/cookie.ts";
 

--- a/src/injection/factories/index.ts
+++ b/src/injection/factories/index.ts
@@ -1,4 +1,4 @@
-export { default as FactoryFunction } from "./factory-function.ts";
+export type { default as FactoryFunction } from "./factory-function.ts";
 export { default as instanceCachingFactory } from "./instance-caching-factory.ts";
 export {
   default as predicateAwareClassFactory,

--- a/src/injection/index.ts
+++ b/src/injection/index.ts
@@ -1,8 +1,8 @@
 import "./reflect.ts";
 
-export {
+export { Lifecycle } from "./types/index.ts";
+export type {
   DependencyContainer,
-  Lifecycle,
   RegistrationOptions,
 } from "./types/index.ts";
 export * from "./decorators/index.ts";

--- a/src/injection/providers/index.ts
+++ b/src/injection/providers/index.ts
@@ -1,9 +1,11 @@
-export { default as ClassProvider, isClassProvider } from "./class-provider.ts";
-export {
-  default as FactoryProvider,
-  isFactoryProvider,
-} from "./factory-provider.ts";
-export { default as InjectionToken, isNormalToken } from "./injection-token.ts";
-export { default as Provider } from "./provider.ts";
-export { default as TokenProvider, isTokenProvider } from "./token-provider.ts";
-export { default as ValueProvider, isValueProvider } from "./value-provider.ts";
+export type { default as ClassProvider } from "./class-provider.ts";
+export { isClassProvider } from "./class-provider.ts";
+export type { default as FactoryProvider } from "./factory-provider.ts";
+export { isFactoryProvider } from "./factory-provider.ts";
+export type { default as InjectionToken } from "./injection-token.ts";
+export { isNormalToken } from "./injection-token.ts";
+export type { default as Provider } from "./provider.ts";
+export type { default as TokenProvider } from "./token-provider.ts";
+export { isTokenProvider } from "./token-provider.ts";
+export type { default as ValueProvider } from "./value-provider.ts";
+export { isValueProvider } from "./value-provider.ts";

--- a/src/injection/types/index.ts
+++ b/src/injection/types/index.ts
@@ -1,5 +1,5 @@
-export { default as constructor } from "./constructor.ts";
-export { default as DependencyContainer } from "./dependency-container.ts";
-export { default as Dictionary } from "./dictionary.ts";
-export { default as RegistrationOptions } from "./registration-options.ts";
+export type { default as constructor } from "./constructor.ts";
+export type { default as DependencyContainer } from "./dependency-container.ts";
+export type { default as Dictionary } from "./dictionary.ts";
+export type { default as RegistrationOptions } from "./registration-options.ts";
 export { default as Lifecycle } from "./lifecycle.ts";


### PR DESCRIPTION
As mentioned in #98, Deno throws a whole bunch of TypeScript compiler errors when run with the `--unstable` command line parameter.

This PR fixes #98 by exporting all reported types using `export type` instead of just a standard `export`.