### PR TITLE
Fix OpenAPI generator

### DIFF
--- a/examples/basic/areas/home/home.controller.ts
+++ b/examples/basic/areas/home/home.controller.ts
@@ -6,6 +6,7 @@ import {
   Get,
   Param,
   Post,
+  Put,
   QueryParam,
   Req,
   Res,
@@ -49,6 +50,16 @@ export class HomeController {
     @QueryParam("c") c: string,
   ) {
     return { a, b, c };
+  }
+
+  @Put("/query")
+  putQuery(
+    @QueryParam("a") a: string,
+    @QueryParam("b") b: string,
+    @QueryParam("c") c: string,
+    @Body() body: any,
+  ) {
+    return { a, b, c, ...body };
   }
 
   @Get("/test")

--- a/openapi/builder/openapi-builder.ts
+++ b/openapi/builder/openapi-builder.ts
@@ -99,7 +99,12 @@ export class OpenApiBuilder {
     return this;
   }
   addPath(path: string, pathItem: oa.PathItemObject): OpenApiBuilder {
-    this.rootDoc.paths[path] = pathItem;
+    // A path can have multiple methods, therefore we must merge them
+    if (this.rootDoc.paths[path]) {
+      this.rootDoc.paths[path] = { ...this.rootDoc.paths[path], ...pathItem };
+    } else {
+      this.rootDoc.paths[path] = pathItem;
+    }
     return this;
   }
   addSchema(

--- a/openapi/openapi.test.ts
+++ b/openapi/openapi.test.ts
@@ -20,6 +20,16 @@ test({
 
     assertEquals(spec.openapi, "3.0.0");
 
+    // Check if all method are present in the path
+    // A single path can have multiple methods (ex: get, put)
+    // TODO find a way to automatically retrieve this list.
+    const expectedquerykeys = ["put", "get"];
+    const querykeys = Object.keys(spec.paths["/app/home/query"]);
+    assertEquals(
+      expectedquerykeys.filter((item) => querykeys.includes(item)).length,
+      expectedquerykeys.length,
+    );
+
     // TODO(irustm) add full tests after implement type reference
   },
 });


### PR DESCRIPTION
OpenAPI does not handle multiple method for a single path.
Added Unit test

Known issue:
Might want to improve the test to not need to hard code the list
of method which exist in the /app/home/query path.
Problem is private metadata not accessible to retrieve the information.