### PR TITLE
Fix invalid immediate response from MiddlewareTarget::onPreRequest

### DIFF
--- a/src/server/handle-native-request.ts
+++ b/src/server/handle-native-request.ts
@@ -91,7 +91,7 @@ async function handleFullServer<TState>(
 
       if (context.response.isImmediately()) {
         respondWith(
-          getResponse({ body: context.response.getRaw() } as ActionResult),
+          getResponse(context.response.getRaw() as ActionResult),
         );
         continue;
       }


### PR DESCRIPTION
The server does send an invalid response if a middleware should respond immediately after the `onPreRequest` call (like the `CorsBuilder`). This pull request should fix that.