### PR TITLE
change(renderer): implement standard renderer for NoContent

### DIFF
--- a/src/renderer/mod.ts
+++ b/src/renderer/mod.ts
@@ -1,4 +1,5 @@
 export * from "./content.ts";
+export * from "./no-content.ts";
 export * from "./view.ts";
 export * from "./redirect.ts";
 export * from "./not-found.ts";

--- a/src/renderer/no-content.ts
+++ b/src/renderer/no-content.ts
@@ -1,0 +1,9 @@
+import { ActionResult } from "../models/response.ts";
+
+export function NoContent(headers: Headers = new Headers()): ActionResult {
+  return {
+    status: 204,
+    headers,
+    __isActionResult: true,
+  };
+}


### PR DESCRIPTION
So far, documentation doesn't explicitly mention how to customize status in responses.

At the same, time, when returning 204 with `Content` renderer (even though `result` parameter is `undefined`), leaves an error as result.

So, to partially sort out this issues, I've created this renderer that might be of use in the future for other people.